### PR TITLE
change brotli library to com.aayushatharva.brotli4j.

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -114,7 +114,7 @@ Additional to `GZip`, this version includes [Brotli](https://en.wikipedia.org/wi
 which is [widely supported](https://caniuse.com/brotli) by modern browsers.
 
 In order to use this compression you will need first to add the 
-[com.nixxcode.jvmbrotli](https://mvnrepository.com/artifact/com.nixxcode.jvmbrotli) dependency 
+[com.aayushatharva.brotli4j](https://mvnrepository.com/artifact/com.aayushatharva.brotli4j) dependency
 in your project (Gradle, Maven, etc). 
 
 **NOTE**: If you are using Gradle, you may need to also include the native library according to your

--- a/pom.xml
+++ b/pom.xml
@@ -194,9 +194,9 @@
 
         <!-- SPARK DEPENDENCIES -->
         <dependency>
-            <groupId>com.nixxcode.jvmbrotli</groupId>
-            <artifactId>jvmbrotli</artifactId>
-            <version>0.2.0</version>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
+            <version>1.12.0</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -50,7 +50,7 @@ public class Response {
         GZIP_COMPRESSED,
         // It will request Spark to compress the output (brotli) and set the BROTLI header
         // NOTE: Brotli is a successor to gzip, it is supported by all major web browsers. It provides better compression than gzip.
-        // Brotli Library is included with `com.nixxcode.jvmbrotli` library
+        // Brotli Library is included with `com.aayushatharva.brotli4j` library
         BROTLI_COMPRESS,
         // It will notify Spark that the output is already BROTLI compressed.
         // In such case, Spark won't compress the output and will ensure the BROTLI header is set.

--- a/src/test/java/spark/examples/brotli/BrotliClient.java
+++ b/src/test/java/spark/examples/brotli/BrotliClient.java
@@ -8,7 +8,7 @@ import java.util.zip.GZIPInputStream;
 
 import spark.utils.IOUtils;
 
-import com.nixxcode.jvmbrotli.dec.BrotliInputStream;
+import com.aayushatharva.brotli4j.decoder.BrotliInputStream;
 
 /**
  * Created by A.Lepe (2022-07-27) based on GzipClient


### PR DESCRIPTION
- com.aayushatharva.brotli4j is actively maintained and a better option than com.nixxcode.jvmbrotli. it is also a drop-in replacement, apart from package rename.
- check for brotli availability only once.