### PR TITLE
update jetty to 11.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <slf4j.version>2.0.5</slf4j.version>
-        <jetty.version>11.0.16</jetty.version>
+        <jetty.version>11.0.21</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <slf4j.version>2.0.5</slf4j.version>
-        <jetty.version>11.0.15</jetty.version>
+        <jetty.version>11.0.16</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
This release addresses:

    https://github.com/advisories/GHSA-58qw-p7qm-5rvh - provides a workaround for direct users of XmlParser
    https://github.com/advisories/GHSA-hmr7-m48g-48f6
    https://github.com/advisories/GHSA-3gh6-v5v9-6v9j
    https://github.com/advisories/GHSA-pwh8-58vv-vw48

And others https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.16